### PR TITLE
Revert "#12 Forward ssh-agent to container"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,14 +33,12 @@ services:
       DB_PASSWORD: drupal
       DB_NAME: drupal
       DB_DRIVER: mysql
-      SSH_AUTH_SOCK: /ssh-agent
       # PHP_XDEBUG: 1
       # PHP_XDEBUG_DEFAULT_ENABLE: 1
       # PHP_XDEBUG_REMOTE_CONNECT_BACK: 0         # This is needed to respect remote.host setting bellow
       # PHP_XDEBUG_REMOTE_HOST: "10.254.254.254"  # You will also need to 'sudo ifconfig lo0 alias 10.254.254.254'
     volumes:
       - codebase:/var/www/html
-      - $SSH_AUTH_SOCK:/ssh-agent # Forward local machine SSH key to docker  
 #      - docker-sync-unison:/var/www/html # Docker-sync for macOS users
 
   nginx:


### PR DESCRIPTION
Reverts nicobot/docker4drupal#13 as it should be applying to boilerplate branch.